### PR TITLE
Fix compo size

### DIFF
--- a/wordle/public/index.html
+++ b/wordle/public/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Ken U GuessIT</title>
+    <title>Ken U Guess</title>
   </head>
   <body  style="margin: 0; background-color: #DBD4D3;">
     <div id="root"></div>

--- a/wordle/src/AboutUsPage/AboutUsPage.js
+++ b/wordle/src/AboutUsPage/AboutUsPage.js
@@ -35,7 +35,7 @@ function AboutUsPage() {
       {hamburgerMenu}
       {hamburgerBlur}
       <button className="back-button" onClick={goHome}>
-        <ArrowBackIcon style={{ width: "97px", height: "77px" }} />
+        <ArrowBackIcon style={{ width: "5vw", height: "auto" }} />
       </button>
       <div className="card">
         <h1 className="title">About us</h1>

--- a/wordle/src/AboutUsPage/AboutUsPage.scss
+++ b/wordle/src/AboutUsPage/AboutUsPage.scss
@@ -7,41 +7,39 @@
 
 .back-button {
   display: fixed;
-  margin-top: 30px;
-  margin-left: 30px;
+  margin-top: 3vh;
+  margin-left: 3vh;
   background-color: transparent;
   border: 0;
   float: left;
+  width: 3vh;
+  height: auto;
 }
 
 .card {
   float: right;
-  margin: 40px 170px auto auto;
-  width: 1518px;
-  height: 858px;
+  margin: 5vh 10vh auto auto;
+  width: 80vw;
+  height: 80vh;
   border: 2px solid black;
   background-color: white;
   border-radius: 20px;
 
-  @include media("<lgdesktop") {
-    width: 1100px;
-    height: 600px;
-  }
 }
 
 .title {
   text-align: center;
   font-size: 65px;
+  margin-top: 2vh;
+  margin-bottom: 2vh;
   @include media("<lgdesktop") {
     font-size: 45px;
-    margin-top: 10px;
-    margin-bottom: 10px;
   }
 }
 
 .text-content {
   max-width: 85%;
-  margin: 30px auto 20px auto;
+  margin: 0 auto 0 auto;
   font-size: 32px;
   @include media("<lgdesktop") {
     font-size: 25px;
@@ -53,9 +51,7 @@
   display: flex;
   margin-left: auto;
   margin-right: auto;
-  @include media("<lgdesktop") {
-    margin-left: 120px;
-  }
+  margin-left: 10vw;
 }
 
 .ken-img {
@@ -63,22 +59,19 @@
   width: 300px;
   @include media("<lgdesktop") {
     height: 180px;
-    width: 160px;
+    width: auto;
   }
 }
 
 .team-img {
   height: 180px;
-  width: 500px;
+  width: auto;
 }
 
 .ken-wrapper {
   text-align: center;
   float: left;
-  margin-right: 90px;
-  @include media(">lgdesktop") {
-    margin-left: 120px;
-  }
+  margin-right: 10vw;
 }
 
 .team-wrapper {

--- a/wordle/src/Components/Header/Header.scss
+++ b/wordle/src/Components/Header/Header.scss
@@ -26,7 +26,7 @@
   width: 100%;
   color: white;
   background-color: #dbd4d3;
-  height: 75px;
+  height: 8vh;
   border-bottom: 0.5px solid black;
   box-shadow: 1px 1px 5px grey;
 }
@@ -34,10 +34,10 @@
 .button-logo {
   position: absolute;
   left: 50%;
-  top: 30px;
+  top: 3vh;
   transform: translate(-50%, -50%);
-  height: 70px;
-  width: 182px;
+  height: 6vh;
+  width: auto;
   background-color: transparent;
   border: 0;
   margin-top: 5px;
@@ -45,9 +45,8 @@
 }
 
 .logo-style {
-  height: 55px;
-  width: 70px;
-  margin-top: 5px;
+  height: 6vh;
+  width: auto;
 }
 
 .hamburger-menu {
@@ -67,13 +66,13 @@
 }
 
 .ham-img {
-  width: 40px;
-  height: 40px;
+  height: 5vh;
+  width: auto;
 }
 
 .acc-img {
-  width: 50px;
-  height: 50px;
+  height: 5vh;
+  width: auto;
 }
 
 .hamburger-menu {

--- a/wordle/src/Components/Keyboard/Keyboard.scss
+++ b/wordle/src/Components/Keyboard/Keyboard.scss
@@ -18,6 +18,11 @@
   color: #fff;
   transform: translate3d(0, 0, 0);
   vertical-align: top;
+  @include media("height<midheight") {
+    width: 40px;
+    height: 40px;
+    margin: 5px 0 0 5px;
+  }
 }
  
 .big-key {

--- a/wordle/src/HomePage/HomePage.scss
+++ b/wordle/src/HomePage/HomePage.scss
@@ -20,6 +20,6 @@ body {
 
 .keyboard {
   position: fixed;
-  bottom: 40px;
+  bottom: 20px;
   width: 100%;
 }

--- a/wordle/src/HomePage/WinPopUp.scss
+++ b/wordle/src/HomePage/WinPopUp.scss
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,700");
 .winpopup-style,
 .overlay {
   width: 100vw;
@@ -14,6 +15,7 @@
 }
 
 .content {
+  font-family: "Open Sans", sans-serif;
   position: absolute;
   top: 30%;
   left: 0;
@@ -30,6 +32,18 @@
 }
 
 .close-btn {
-  width: 100px;
-  height: 30px;
+  width: 225px;
+    height: 50px;
+    margin: 7px;
+    border: none;
+    border-radius: 5px;
+    padding: 5px;
+    font-size: 16px;
+    background: #43a047;
+    color: #fff;
+    cursor: pointer;
+}
+
+.close-btn:hover {
+  background: #2e7d32;
 }

--- a/wordle/src/MultiplayerPage/GameContent.scss
+++ b/wordle/src/MultiplayerPage/GameContent.scss
@@ -14,3 +14,10 @@
   width: 50%;
   float: right;
 }
+
+
+.keyboard {
+  position: fixed;
+  bottom: 20px;
+  width: 100%;
+}

--- a/wordle/src/Utils/include-media.scss
+++ b/wordle/src/Utils/include-media.scss
@@ -33,6 +33,7 @@ $breakpoints: (
   "tablet": 768px,
   "desktop": 1024px,
   "lgdesktop": 1920px,
+  "midheight": 900px,
 ) !default;
 
 ///


### PR DESCRIPTION
This PR does the following:
- Make the size of the Header, About Us page, always proportional to the screen height and width;
- Resize the size of the Keyboard so that it fits into smaller screens;

QA Steps:
1. Check the component size on HomePage, AboutPage, MultiplayerPage, components should displayed properly without overlapping each other or out of position;
2. Inspect any of the page above, then stretch the size of the page, the header should change size based on page height, for example:
![image](https://user-images.githubusercontent.com/26106407/163695203-ab1753c9-7a92-4be7-b178-592e5703db69.png)
![image](https://user-images.githubusercontent.com/26106407/163695205-856e4a4b-e671-4540-a95c-b4fa2502b905.png)
3.  Go to about page, all components should be responsive to any height and width, for example:
![image](https://user-images.githubusercontent.com/26106407/163695214-9e745917-094a-49b8-8b64-f4cbc570f689.png)
![image](https://user-images.githubusercontent.com/26106407/163695218-821b249e-366f-4d32-9d0f-b7083f68fa4f.png)
