### PR TITLE
Waiting-screen-update

### DIFF
--- a/wordle/src/MultiplayerPage/Timer.js
+++ b/wordle/src/MultiplayerPage/Timer.js
@@ -21,28 +21,28 @@ function Timer({socket, room, updateShowGame, updateShowTimer}) {
             }
             setTimeOn(timer.on);
         });
- 
+
         let interval = null;
-          if(timerOn){
+        let tempTime = time;
+        if(timerOn){
             interval = setInterval(() => {
-              setTime(prevTime => prevTime - 50);
-              if(time < 1000){
-                  setTimeOn(false);
-                  updateShowTimer(false);
-                  updateShowGame(true);
-                  clearInterval(interval);
-              } else {
-                  socket.emit("start", timeData);
-              }
+                tempTime -= 20;
+                if(tempTime < 1000){
+                    setTimeOn(false);
+                    updateShowTimer(false);
+                    updateShowGame(true);
+                } else {
+                    setTime(tempTime);
+                    socket.emit("start", timeData);
+                }
             }, 10)
-          } else {
-            clearInterval(interval);
-          }
+        }
              
-        return () => clearInterval(interval);
-   
-    }, [timerOn, time, socket]);
- 
+        return function cleanup() {
+            clearInterval(interval);
+        }
+    }, []);
+
     return (
         <div className="Timer-container">
             <div className="time">

--- a/wordle/src/MultiplayerPage/WaitingScreen.js
+++ b/wordle/src/MultiplayerPage/WaitingScreen.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, {useState, useEffect} from "react";
+import React, {useState} from "react";
 import GameContent from "./GameContent";
 import Timer from "./Timer";
 import "./WaitingScreen.scss";
@@ -16,18 +16,16 @@ function WaitingScreen({socket, username, room}) {
         setShowTimer(value);
     }
  
-    useEffect(() => {
-        socket.on("start_countdown", (val) => {
-            setShowTimer(val);
-        });
+    socket.on("start_countdown", (val) => {
+        setShowTimer(val);
+    });
 
-        socket.on("opponent", (joined) => {
-            if(joined){
-                setShowTimer(true);
-                socket.emit("show_timer", room);
-            }
-        });
-    }, [socket]);
+    socket.on("opponent", (joined) => {
+        if(joined){
+            setShowTimer(true);
+            socket.emit("show_timer", room);
+        }
+    });
 
     return (
         <div className="waiting-screen-container">


### PR DESCRIPTION
Description:
Fixed previous consecutive game issue. Now after users finish a multiplier game, they can navigate back to the multiplier page, join a game, view the waiting-screen, and watch the countdown before the multiplier game ensues. 

Steps to Test:
1. run server and react app
2. go to multiplier page
3. join a room
4. on separate browser, continue steps 2-3
5. Users should see a countdown that leads to the multiplier game
6. (Without refreshing) navigate back to the multiplier page and join a new room on both browsers
7. Once second user joins the room, step 5 should occur